### PR TITLE
feat: add file_storage extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ For more details, see [builder-config.yaml](builder-config.yaml).
 | Component | Description | Documentation |
 |-----------|-------------|---------------|
 | health_check | Health check extension | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension) |
+| file_storage | File storage extension | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) |
 
 ## Build
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -38,3 +38,4 @@ providers:
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.125.0

--- a/cmd/sacloud-otel-collector/components.go
+++ b/cmd/sacloud-otel-collector/components.go
@@ -17,6 +17,7 @@ import (
 	fileexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 	elasticsearchexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
+	filestorage "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	batchprocessor "go.opentelemetry.io/collector/processor/batchprocessor"
 	memorylimiterprocessor "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	resourceprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
@@ -38,12 +39,14 @@ func components() (otelcol.Factories, error) {
 
 	factories.Extensions, err = otelcol.MakeFactoryMap[extension.Factory](
 		healthcheckextension.NewFactory(),
+		filestorage.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err
 	}
 	factories.ExtensionModules = make(map[component.Type]string, len(factories.Extensions))
 	factories.ExtensionModules[healthcheckextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0"
+	factories.ExtensionModules[filestorage.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.125.0"
 
 	factories.Receivers, err = otelcol.MakeFactoryMap[receiver.Factory](
 		otlpreceiver.NewFactory(),

--- a/cmd/sacloud-otel-collector/go.mod
+++ b/cmd/sacloud-otel-collector/go.mod
@@ -4,13 +4,14 @@ module go.opentelemetry.io/collector/cmd/builder
 
 go 1.23.7
 
-toolchain go1.24.4
+toolchain go1.24.5
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.125.0
@@ -289,6 +290,7 @@ require (
 	go.elastic.co/apm/module/apmzap/v2 v2.7.0 // indirect
 	go.elastic.co/apm/v2 v2.7.0 // indirect
 	go.elastic.co/fastjson v1.5.0 // indirect
+	go.etcd.io/bbolt v1.4.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.125.0 // indirect

--- a/cmd/sacloud-otel-collector/go.sum
+++ b/cmd/sacloud-otel-collector/go.sum
@@ -634,6 +634,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthchecke
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.125.0/go.mod h1:9sqOk3tB/ss8mPe55CcQDk7P/uhbDkuYDq4DCUCh7eI=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.125.0 h1:cT04h6LstyuEKyonbMnz8Tz8U0+0vuPUxeNXBKmO2dc=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.125.0/go.mod h1:GeOnmgaagn8/jNZlAsn4Pr6oDdS0xzGDkh6wh1ojMv4=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.125.0 h1:HTfQ4AprvcIFAwmPxcphifLn79IoOgukosWMajdGMfI=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.125.0/go.mod h1:DROjh+xukN0yRKfZ7DaLoZZ/2aBJ3OQLFhEBPCdvhQM=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.125.0 h1:d9d/fkOBNs89BJZblajk7EUJkc1HTwWwymxsEPSBEms=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.125.0/go.mod h1:CxOkwlT2SsHtnWe/lsvHzS95JYMcGkPOUoG9epwHyzc=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.125.0 h1:JxtfPyQWRcE3OsC4JV85WEPG5yR4PnWC3L4UVhyyjPk=
@@ -877,6 +879,8 @@ go.elastic.co/apm/v2 v2.7.0 h1:fbsy3BmTTedIbj7+1Ay9Zpdfuztd8RUk7Dm0JvxRW/M=
 go.elastic.co/apm/v2 v2.7.0/go.mod h1:f1Sr3rVJju5winTjsJtKzofdU32L7+Mw/c23cVcn3Io=
 go.elastic.co/fastjson v1.5.0 h1:XAQ7wrNObNnDiXC8qQKblkmLwh0vJjX3Z/jEj6/08SI=
 go.elastic.co/fastjson v1.5.0/go.mod h1:WtvH5wz8z9pDOPqNYSYKoLLv/9zCWZLeejHWuvdL/EM=
+go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
+go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Summary

Add file_storage extension to sacloud-otel-collector. This extension enables persistent storage for component states (checkpoints, offsets, etc.) on the local filesystem.

Changes

- Added file_storage extension to builder-config.yaml
- Updated README.md to include file_storage in the Extensions table