### PR TITLE
Allow http:// endpoints in sacloud exporter

### DIFF
--- a/exporter/sacloudexporter/README.md
+++ b/exporter/sacloudexporter/README.md
@@ -36,9 +36,9 @@ At least one of the following signal configurations must be specified:
 
 The `endpoint` field accepts either:
 - An endpoint identifier from SAKURA Cloud control panel (e.g., `"123456789012"`)
-- A full URL (e.g., `"https://123456789012.metrics.monitoring.global.api.sacloud.jp/prometheus/api/v1/write"`)
+- A full URL starting with `http://` or `https://` (e.g., `"https://123456789012.metrics.monitoring.global.api.sacloud.jp/prometheus/api/v1/write"`)
 
-If only an identifier is provided, it will be expanded to the full URL automatically.
+If only an identifier is provided, it will be expanded to the full URL (with `https://`) automatically.
 
 ### Optional Settings
 

--- a/exporter/sacloudexporter/config.go
+++ b/exporter/sacloudexporter/config.go
@@ -81,7 +81,7 @@ type EndpointConfig struct {
 
 var numericIDPattern = regexp.MustCompile(`^[0-9]+$`)
 
-// validateEndpoint checks that the endpoint is either a numeric ID or a full URL starting with "https://".
+// validateEndpoint checks that the endpoint is either a numeric ID or a full URL starting with "http://" or "https://".
 func validateEndpoint(endpoint, field string) error {
 	if endpoint == "" {
 		return nil
@@ -92,7 +92,7 @@ func validateEndpoint(endpoint, field string) error {
 	if numericIDPattern.MatchString(endpoint) {
 		return nil
 	}
-	return fmt.Errorf(`%s.endpoint must be a numeric ID or a full URL starting with "https://"`, field)
+	return fmt.Errorf(`%s.endpoint must be a numeric ID or a full URL starting with "http://" or "https://"`, field)
 }
 
 // Validate checks if the configuration is valid.
@@ -136,9 +136,9 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-// isFullURL returns true if the endpoint is a full URL (starts with https://).
+// isFullURL returns true if the endpoint is a full URL (starts with http:// or https://).
 func isFullURL(endpoint string) bool {
-	return strings.HasPrefix(endpoint, "https://")
+	return strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")
 }
 
 // MetricsEndpointURL returns the full URL for metrics endpoint.

--- a/exporter/sacloudexporter/config_test.go
+++ b/exporter/sacloudexporter/config_test.go
@@ -105,14 +105,14 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "invalid endpoint - http URL",
+			name: "valid full URL endpoint - http",
 			cfg: Config{
 				Metrics: MetricsEndpointConfig{
 					Endpoint: "http://example.com",
 					Token:    "test-token",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "invalid endpoint - bare hostname",
@@ -156,7 +156,7 @@ func TestValidateEndpoint(t *testing.T) {
 		{"0", false},
 		{"https://example.com", false},
 		{"https://123456789012.metrics.monitoring.global.api.sacloud.jp/prometheus/api/v1/write", false},
-		{"http://example.com", true},
+		{"http://example.com", false},
 		{"example.com", true},
 		{"abc123", true},
 		{"abc", true},
@@ -183,7 +183,7 @@ func TestIsFullURL(t *testing.T) {
 		{"https://123456789012.logs.monitoring.global.api.sacloud.jp", true},
 		{"123456789012", false},
 		{"example.com", false},
-		{"http://example.com", false}, // only https is supported
+		{"http://example.com", true},
 		{"", false},
 	}
 


### PR DESCRIPTION
## What

sacloud exporter の `endpoint` で `http://` から始まる URL も受け付けるようにした。従来は `https://` のみ許容していた。

- `isFullURL` が `http://` / `https://` 両方を判定
- バリデーションエラーメッセージと README を更新
- エンドポイント識別子(数値ID)は従来どおり `https://` に展開

## Why

ローカルゲートウェイやプロキシなど plain-HTTP のエンドポイントへ送信したいケースに対応するため。