### PR TITLE
Promote sacloud exporter stability to alpha

### DIFF
--- a/exporter/sacloudexporter/README.md
+++ b/exporter/sacloudexporter/README.md
@@ -3,10 +3,10 @@
 <!-- status autance added by mdatagen. Do not edit. -->
 | Status                   |                                              |
 | ------------------------ | -------------------------------------------- |
-| Stability                | [development]: metrics, logs, traces         |
+| Stability                | [alpha]: metrics, logs, traces               |
 | Distributions            | [sacloud-otel-collector]                     |
 
-[development]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development
+[alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [sacloud-otel-collector]: https://github.com/sacloud/sacloud-otel-collector
 
 <!-- end autance added section -->

--- a/exporter/sacloudexporter/factory.go
+++ b/exporter/sacloudexporter/factory.go
@@ -18,9 +18,9 @@ func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
 		component.MustNewType(typeStr),
 		createDefaultConfig,
-		exporter.WithMetrics(createMetricsExporter, component.StabilityLevelDevelopment),
-		exporter.WithLogs(createLogsExporter, component.StabilityLevelDevelopment),
-		exporter.WithTraces(createTracesExporter, component.StabilityLevelDevelopment),
+		exporter.WithMetrics(createMetricsExporter, component.StabilityLevelAlpha),
+		exporter.WithLogs(createLogsExporter, component.StabilityLevelAlpha),
+		exporter.WithTraces(createTracesExporter, component.StabilityLevelAlpha),
 	)
 }
 

--- a/exporter/sacloudexporter/metadata.yaml
+++ b/exporter/sacloudexporter/metadata.yaml
@@ -3,7 +3,7 @@ type: sacloud
 status:
   class: exporter
   stability:
-    development: [metrics, logs, traces]
+    alpha: [metrics, logs, traces]
   distributions: []
   codeowners:
     active: []


### PR DESCRIPTION
## What

sacloud exporter の stability を `development` から `alpha` に引き上げ(metrics / logs / traces)。

- `factory.go`: `StabilityLevelDevelopment` → `StabilityLevelAlpha`
- `metadata.yaml`: `stability.alpha`
- `README.md`: status テーブルとリンクを更新

## Why

本番である程度稼働し実績が積まれたため、安定度レベルを一段引き上げる。