### PR TITLE
Add kafka exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ For more details, see [builder-config.yaml](builder-config.yaml).
 | file | File exporter | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter) |
 | elasticsearch | Elasticsearch exporter | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter) |
 | awss3 | AWS S3 exporter | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter) |
+| kafka | Kafka exporter | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter) |
 | sacloud | SAKURA Cloud Monitoring Suite exporter | See [Config examples](#sakuracloud-monitoring-suite) |
 | mackerelotlp | Mackerel OTLP exporter | [Documentation](https://github.com/mackerelio/opentelemetry-collector-mackerel/tree/main/exporter/mackerelotlpexporter) |
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -11,6 +11,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0
   - gomod: github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter v0.0.0
     path: ./exporter/sacloudexporter
   - gomod: github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.14.0

--- a/cmd/sacloud-otel-collector/components.go
+++ b/cmd/sacloud-otel-collector/components.go
@@ -7,6 +7,7 @@ import (
 	awss3exporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
 	elasticsearchexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	fileexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
+	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	prometheusremotewriteexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	filestorage "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
@@ -106,6 +107,7 @@ func components() (otelcol.Factories, error) {
 		fileexporter.NewFactory(),
 		elasticsearchexporter.NewFactory(),
 		awss3exporter.NewFactory(),
+		kafkaexporter.NewFactory(),
 		sacloudexporter.NewFactory(),
 		mackerelotlpexporter.NewFactory(),
 	)
@@ -120,6 +122,7 @@ func components() (otelcol.Factories, error) {
 		fileexporter.NewFactory().Type():                  "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0",
 		elasticsearchexporter.NewFactory().Type():         "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0",
 		awss3exporter.NewFactory().Type():                 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.154.0",
+		kafkaexporter.NewFactory().Type():                 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0",
 		sacloudexporter.NewFactory().Type():               "github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter v0.0.0",
 		mackerelotlpexporter.NewFactory().Type():          "github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.14.0",
 	})

--- a/cmd/sacloud-otel-collector/go.mod
+++ b/cmd/sacloud-otel-collector/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.154.0
@@ -267,9 +268,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.154.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.154.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.154.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.154.0 // indirect

--- a/cmd/sacloud-otel-collector/go.sum
+++ b/cmd/sacloud-otel-collector/go.sum
@@ -599,6 +599,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearch
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0/go.mod h1:dxcNIcQrmgssQ2ieWO5AwCS4uwbvZZwU5WUhjE5UvLg=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0 h1:BB7O4J9o7bd58feM2UndH1BIaxTgscJF2KqtOf5qCZ0=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0/go.mod h1:fdP8j5kBJIGDjwlMX9HaqyCb9SGa9TVJmv8Ta/ANUQU=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0 h1:ye7ajYUGf94Pl3VgtyrOmy+99kMWjx1rCh4HiCFncPM=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0/go.mod h1:eM6BH8EvOpChf1tzUDyd9R5M8LHnssZZkWnocWQ+G+8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.154.0 h1:4zX2htgy57I+x0mUrVhnG/P4zH6YLwmjlZWdebfenC8=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.154.0/go.mod h1:+KCfDMpdwmpzcvbUkqKZGkXbE6PJGfiqBjoC0m5MMa4=
 github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.154.0 h1:+0L7+SKyykckkwZIpJkMbIt+r78RmSIXkI86bVRlIpU=
@@ -637,6 +639,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcompone
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.154.0/go.mod h1:HQ0oddvYpiv9cSXw2nOhHjhnGcSVflCKh2r/qnq0LjA=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.154.0 h1:5Q9Ojr0VtNQBc1KafAIsKfVqPDPjOHPhJy++1u6ywSU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.154.0/go.mod h1:vqP1TyReZIO6VIZ2G1kT1rPletB/+kLxLKVLAMH36Pc=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.154.0 h1:pEUnE9gW6YAK4UDH6q4um3yd+p0CehULd9Hoz0LjdHw=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.154.0/go.mod h1:2oYkB64XHGQQ4jeqvRQPMAdRFDYKZHh+BIy3bkerToU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.154.0 h1:FhoN9npg3mrZgZIKYY/zwXkBJIZr3N3CnRkAg5OW+uA=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.154.0/go.mod h1:prSVk+dXkJXIBu1WRSWp2m/+Zqlj8JYBFw+uvomlLfg=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.154.0 h1:7qrDTUYpvpVSI92LkPDspYDS7DeVxdZ1OrpiBrAO0mE=
@@ -645,6 +649,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.154.0 h1
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.154.0/go.mod h1:viTQmXsOlitcnJrWjCju98OSTSp1zoOB59cLf4k7gzs=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.154.0 h1:wEwKluYc4FxTePvWEL+d8dfYHqkY7y94fekHCiRsFm4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.154.0/go.mod h1:7FsrdfjtOY9pYmRgqHk/Q4hBliCpqbZLw3yEizE75js=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.154.0 h1:W1yfCx/8xA9FEQUXyh4vnuAPNGXBktR3MkJAULqILpE=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.154.0/go.mod h1:CnkW4xd+Xa6MvVtuY5CKkQtEdb2Sazq7E4rRI/F7nJY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.154.0 h1:AaeGGr8fJVLEj1Iz26KG5yLA7qyKUrcJkW2Uy1O2A9w=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.154.0/go.mod h1:QQ3PP/qLuRI1lZ8jpqoF0Squah5b1QFwUUQlp+vXcTY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.154.0 h1:6dkQJ3TMMojjz8rCNULD19c+9m/svErzgZk8yFKaSGw=


### PR DESCRIPTION
## What

Add `kafkaexporter` v0.154.0 to the collector and list it in the README component table.

## Why

The collector already includes the kafka receiver; adding the kafka exporter enables exporting telemetry (metrics, logs, traces) to Kafka as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)