### PR TITLE
Add Windows and macOS binaries to release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,16 @@ builds:
     binary: sacloud-otel-collector
     goos:
       - linux
+      - windows
+      - darwin
     goarch:
       - amd64
       - arm64
+archives:
+  - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 release:
   use_existing_draft: true
 checksum:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,18 @@ OpenTelemetry collector for [sacloud](https://github.com/sacloud).
 
 Pre-built binaries are available on [GitHub Releases](https://github.com/sacloud/sacloud-otel-collector/releases):
 
-1. Download the tar.gz archive for your platform from the latest release
-2. Extract the archive: `tar xzf sacloud-otel-collector_*.tar.gz`
+1. Download the archive for your platform from the latest release (tar.gz for Linux/macOS, zip for Windows)
+2. Extract the archive: `tar xzf sacloud-otel-collector_*.tar.gz` (Linux/macOS) or unzip `sacloud-otel-collector_*.zip` (Windows)
 3. Run with your configuration:
 
 ```bash
 ./sacloud-otel-collector --config config.yml
+```
+
+On Windows:
+
+```powershell
+.\sacloud-otel-collector.exe --config config.yml
 ```
 
 ### Container Image


### PR DESCRIPTION
## What

- Add `windows` and `darwin` (amd64/arm64) to goreleaser build targets
- Package Windows binaries as zip archives; Linux and macOS remain tar.gz
- Update the README Release Binary section for the new platforms

## Why

Currently only Linux binaries are released. This makes pre-built binaries available for Windows and macOS users as well.

Verified locally with `goreleaser release --snapshot --clean`: all six archives are produced and the Windows zips contain `sacloud-otel-collector.exe`; existing Linux tar.gz/deb/rpm outputs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)