### PR TITLE
Add e2e test against sakumock on Linux, macOS and Windows CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,41 @@
+name: e2e
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache-dependency-path: cmd/sacloud-otel-collector/go.sum
+
+      - name: Build collector
+        shell: bash
+        run: go build -o ../../sacloud-otel-collector$(go env GOEXE) .
+        working-directory: cmd/sacloud-otel-collector
+
+      - name: Install sakumock
+        shell: bash
+        run: go install "github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@${SAKUMOCK_VERSION}"
+        env:
+          SAKUMOCK_VERSION: v0.6.0
+
+      - name: Run e2e test
+        shell: bash
+        run: go test -v ./...
+        working-directory: e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,36 @@ jobs:
           docker run --rm ghcr.io/sacloud/sacloud-otel-collector:$VERSION --version
         env:
           VERSION: ${{ github.sha }}
+
+  e2e:
+    name: e2e (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+          cache-dependency-path: cmd/sacloud-otel-collector/go.sum
+
+      - name: Build collector
+        shell: bash
+        run: go build -o ../../sacloud-otel-collector$(go env GOEXE) .
+        working-directory: cmd/sacloud-otel-collector
+
+      - name: Install sakumock
+        shell: bash
+        run: go install "github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@${SAKUMOCK_VERSION}"
+        env:
+          SAKUMOCK_VERSION: v0.6.0
+
+      - name: Run e2e test
+        shell: bash
+        run: go test -v ./...
+        working-directory: e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,36 +38,3 @@ jobs:
           docker run --rm ghcr.io/sacloud/sacloud-otel-collector:$VERSION --version
         env:
           VERSION: ${{ github.sha }}
-
-  e2e:
-    name: e2e (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26"
-          cache-dependency-path: cmd/sacloud-otel-collector/go.sum
-
-      - name: Build collector
-        shell: bash
-        run: go build -o ../../sacloud-otel-collector$(go env GOEXE) .
-        working-directory: cmd/sacloud-otel-collector
-
-      - name: Install sakumock
-        shell: bash
-        run: go install "github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@${SAKUMOCK_VERSION}"
-        env:
-          SAKUMOCK_VERSION: v0.6.0
-
-      - name: Run e2e test
-        shell: bash
-        run: go test -v ./...
-        working-directory: e2e

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ If you want to add a new component of otel collector, modify [builder-config.yam
 
 ### E2E test
 
-CI runs an end-to-end test on Linux, macOS and Windows: a filelog receiver reads a file and the `sacloud` exporter sends the logs to the [sakumock](https://github.com/sacloud/sakumock) monitoring-suite data plane, asserting the dumped payload. To run it locally:
+CI runs an end-to-end test on Linux, macOS and Windows for each push to the `main` branch: a filelog receiver reads a file and the `sacloud` exporter sends the logs to the [sakumock](https://github.com/sacloud/sakumock) monitoring-suite data plane, asserting the dumped payload. To run it locally:
 
 ```bash
 make

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ CI runs an end-to-end test on Linux, macOS and Windows: a filelog receiver reads
 
 ```bash
 make
-go install github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@latest
+go install github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@v0.6.0
 cd e2e && go test -v ./...
 ```
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,16 @@ service:
 
 If you want to add a new component of otel collector, modify [builder-config.yaml](builder-config.yaml). Then run `make build-src && make` to build the collector.
 
+### E2E test
+
+CI runs an end-to-end test on Linux, macOS and Windows: a filelog receiver reads a file and the `sacloud` exporter sends the logs to the [sakumock](https://github.com/sacloud/sakumock) monitoring-suite data plane, asserting the dumped payload. To run it locally:
+
+```bash
+make
+go install github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@latest
+cd e2e && go test -v ./...
+```
+
 ## Automation
 
 GitHub Actions are used to automate the build and release process. The following steps are performed:

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -24,11 +24,6 @@ import (
 	"time"
 )
 
-const (
-	dataPlaneAddr   = "127.0.0.1:28084"
-	healthCheckAddr = "127.0.0.1:13133"
-)
-
 func TestFilelogToSakumock(t *testing.T) {
 	collector, err := filepath.Abs(filepath.Join("..", collectorBinName()))
 	if err != nil {
@@ -41,6 +36,11 @@ func TestFilelogToSakumock(t *testing.T) {
 	if err != nil {
 		t.Skip("sakumock-monitoringsuite not found in PATH; skipping e2e")
 	}
+
+	// Both servers are external processes, so their ports must be picked
+	// before they start; freeLoopbackAddr is racy but good enough here.
+	dataPlaneAddr := freeLoopbackAddr(t)   // sakumock data plane (collector exports here)
+	healthCheckAddr := freeLoopbackAddr(t) // collector health_check (readiness probe)
 
 	dumpDir := t.TempDir()
 	startProcess(t, "sakumock", sakumock,
@@ -147,6 +147,19 @@ func randomHex(t *testing.T) string {
 func readFile(path string) string {
 	b, _ := os.ReadFile(path)
 	return string(b)
+}
+
+// freeLoopbackAddr reserves a loopback port by binding and immediately
+// closing a listener.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate free port: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
 }
 
 func waitListen(t *testing.T, addr string, timeout time.Duration) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,180 @@
+// Package e2e runs the built sacloud-otel-collector binary against the
+// sakumock monitoring-suite data plane (https://github.com/sacloud/sakumock):
+// a filelog receiver tails a file, the sacloud exporter forwards its lines as
+// OTLP/HTTP logs to the mock, and the test asserts the mock's JSON dump
+// contains what was written.
+//
+// It skips unless ../sacloud-otel-collector (built by `make`) exists and
+// sakumock-monitoringsuite is on PATH:
+//
+//	go install github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@latest
+package e2e_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	dataPlaneAddr   = "127.0.0.1:28084"
+	healthCheckAddr = "127.0.0.1:13133"
+)
+
+func TestFilelogToSakumock(t *testing.T) {
+	collector, err := filepath.Abs(filepath.Join("..", collectorBinName()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(collector); err != nil {
+		t.Skipf("%s not found (build it with `make`); skipping e2e", collector)
+	}
+	sakumock, err := exec.LookPath("sakumock-monitoringsuite")
+	if err != nil {
+		t.Skip("sakumock-monitoringsuite not found in PATH; skipping e2e")
+	}
+
+	dumpDir := t.TempDir()
+	startProcess(t, "sakumock", sakumock,
+		"--enable-data-plane",
+		"--data-plane-addr", dataPlaneAddr,
+		"--data-plane-dump-dir", dumpDir,
+	)
+	waitListen(t, dataPlaneAddr, 30*time.Second)
+
+	logFile := filepath.Join(t.TempDir(), "app.log")
+	if err := os.WriteFile(logFile, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := fmt.Sprintf(`
+receivers:
+  filelog:
+    include: [%q]
+    start_at: beginning
+exporters:
+  sacloud:
+    logs:
+      endpoint: http://%s
+      token: log-dummy
+extensions:
+  health_check:
+    endpoint: %s
+service:
+  telemetry:
+    metrics:
+      level: none
+  extensions: [health_check]
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [sacloud]
+`, filepath.ToSlash(logFile), dataPlaneAddr, healthCheckAddr)
+	cfgFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgFile, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	collectorLog := startProcess(t, "collector", collector, "--config", cfgFile)
+	waitListen(t, healthCheckAddr, 60*time.Second)
+
+	marker := "sacloud-otel-collector e2e marker " + randomHex(t)
+	appendLine(t, logFile, marker)
+
+	if !waitForDumpContaining(dumpDir, "otlp-logs-", marker, 60*time.Second) {
+		t.Errorf("no otlp-logs-* dump containing %q in %s; collector log:\n%s",
+			marker, dumpDir, readFile(collectorLog))
+	}
+}
+
+func collectorBinName() string {
+	if runtime.GOOS == "windows" {
+		return "sacloud-otel-collector.exe"
+	}
+	return "sacloud-otel-collector"
+}
+
+// startProcess runs a binary as a subprocess killed on test cleanup and
+// returns the path of the file capturing its combined output.
+func startProcess(t *testing.T, name, bin string, args ...string) string {
+	t.Helper()
+	logf, err := os.CreateTemp(t.TempDir(), name+"-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout, cmd.Stderr = logf, logf
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = logf.Close()
+	})
+	return logf.Name()
+}
+
+func appendLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func randomHex(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func readFile(path string) string {
+	b, _ := os.ReadFile(path)
+	return string(b)
+}
+
+func waitListen(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, time.Second); err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to listen", addr)
+}
+
+// waitForDumpContaining polls dir until a file with the given name prefix
+// contains the marker string.
+func waitForDumpContaining(dir, prefix, marker string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), prefix) &&
+				strings.Contains(readFile(filepath.Join(dir, e.Name())), marker) {
+				return true
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return false
+}

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,3 +1,3 @@
 module github.com/sacloud/sacloud-otel-collector/e2e
 
-go 1.25
+go 1.25.0

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,0 +1,3 @@
+module github.com/sacloud/sacloud-otel-collector/e2e
+
+go 1.25


### PR DESCRIPTION
## What

- Add an e2e test (`e2e/`, a standalone stdlib-only Go module): it starts [sakumock](https://github.com/sacloud/sakumock)'s monitoring-suite data plane with `--data-plane-dump-dir`, runs the built collector with a filelog receiver and the `sacloud` exporter pointed at the data plane (loopback ports allocated dynamically), appends a marker line to the watched file, and asserts the dumped OTLP logs JSON contains it. The test skips when the collector binary or `sakumock-monitoringsuite` (pinned to v0.6.0) is missing.
- Add a dedicated `e2e` workflow running the test on `ubuntu-latest`, `macos-latest` and `windows-latest`, triggered on pushes to `main` (and manually via `workflow_dispatch`) since the 3-OS job is slow to run per pull request.

## Why

CI only built the collector and validated configs on Ubuntu; no OS actually verified that telemetry flows end-to-end. With Windows and macOS binaries now released, all three platforms should exercise the real data path (filelog → sacloud exporter → OTLP/HTTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)