### PR TITLE
Limit goreleaser build parallelism to avoid runner OOM

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -49,7 +49,9 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2"
-          args: release
+          # Limit concurrent builds: linking this collector peaks at ~4GB per
+          # target, and the default parallelism (CPU count) OOMs the runner.
+          args: release --parallelism 2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.tagpr.outputs.tag != '' || inputs.tag != '' }}


### PR DESCRIPTION
## What

Run goreleaser with `--parallelism 2` in the release workflow.

## Why

The v0.7.1 release job was killed without any error output while building (https://github.com/sacloud/sacloud-otel-collector/actions/runs/28849404281/job/85560799656). With Windows/macOS added there are now six build targets, and the default parallelism (CPU count = 4 on ubuntu-latest) builds four ~4GB-peak cross-compiles concurrently, exceeding the runner's 16GB memory. Capping at 2 keeps the job within memory; local `make dist`/`make release` are unaffected.

The flag lives in the workflow `args:` (not `.goreleaser.yml`) so a `workflow_dispatch` re-run for the existing v0.7.1 tag picks it up: the workflow definition comes from main while the tag's source is checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)