### PR TITLE
Add windowseventlogreceiver and Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,10 @@ jobs:
         with:
           go-version: "1.26"
 
-      - name: build and test
+      - name: build
         shell: bash
         run: |
-          go build -o ../../sacloud-otel-collector.exe .
-          ../../sacloud-otel-collector.exe components
-          ../../sacloud-otel-collector.exe --version
+          go build -o ../../sacloud-otel-collector$(go env GOEXE) .
+          ../../sacloud-otel-collector$(go env GOEXE) components
+          ../../sacloud-otel-collector$(go env GOEXE) --version
         working-directory: cmd/sacloud-otel-collector

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,23 @@ jobs:
           docker run --rm ghcr.io/sacloud/sacloud-otel-collector:$VERSION --version
         env:
           VERSION: ${{ github.sha }}
+
+  test-windows:
+    name: test build (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+
+      - name: build and test
+        shell: bash
+        run: |
+          go build -o ../../sacloud-otel-collector.exe .
+          ../../sacloud-otel-collector.exe components
+          ../../sacloud-otel-collector.exe --version
+        working-directory: cmd/sacloud-otel-collector

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ For more details, see [builder-config.yaml](builder-config.yaml).
 | filelog | File log receiver | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver) |
 | fluentforward | Fluent Forward receiver | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver) |
 | journald | Journald receiver | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver) |
+| windowseventlog | Windows Event Log receiver (Windows only) | [Documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver) |
 
 ### Processors
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -37,6 +37,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.154.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0
 
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.60.0

--- a/cmd/sacloud-otel-collector/components.go
+++ b/cmd/sacloud-otel-collector/components.go
@@ -26,6 +26,7 @@ import (
 	journaldreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
 	kafkareceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 	prometheusreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+	windowseventlogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
 	sacloudexporter "github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
@@ -84,19 +85,21 @@ func components() (otelcol.Factories, error) {
 		filelogreceiver.NewFactory(),
 		fluentforwardreceiver.NewFactory(),
 		journaldreceiver.NewFactory(),
+		windowseventlogreceiver.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err
 	}
 	factories.ReceiverModules = makeModulesMap(factories.Receivers, map[component.Type]string{
-		otlpreceiver.NewFactory().Type():          "go.opentelemetry.io/collector/receiver/otlpreceiver v0.154.0",
-		prometheusreceiver.NewFactory().Type():    "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0",
-		hostmetricsreceiver.NewFactory().Type():   "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.154.0",
-		jaegerreceiver.NewFactory().Type():        "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.154.0",
-		kafkareceiver.NewFactory().Type():         "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.154.0",
-		filelogreceiver.NewFactory().Type():       "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.154.0",
-		fluentforwardreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.154.0",
-		journaldreceiver.NewFactory().Type():      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.154.0",
+		otlpreceiver.NewFactory().Type():            "go.opentelemetry.io/collector/receiver/otlpreceiver v0.154.0",
+		prometheusreceiver.NewFactory().Type():      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0",
+		hostmetricsreceiver.NewFactory().Type():     "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.154.0",
+		jaegerreceiver.NewFactory().Type():          "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.154.0",
+		kafkareceiver.NewFactory().Type():           "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.154.0",
+		filelogreceiver.NewFactory().Type():         "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.154.0",
+		fluentforwardreceiver.NewFactory().Type():   "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.154.0",
+		journaldreceiver.NewFactory().Type():        "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.154.0",
+		windowseventlogreceiver.NewFactory().Type(): "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0",
 	})
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](

--- a/cmd/sacloud-otel-collector/go.mod
+++ b/cmd/sacloud-otel-collector/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0
 	github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter v0.0.0
 	go.opentelemetry.io/collector/component v1.60.0
 	go.opentelemetry.io/collector/confmap v1.60.0
@@ -62,6 +63,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
+	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Code-Hex/go-generics-cache v1.5.1 // indirect
 	github.com/DeRuina/timberjack v1.4.5 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/Showmax/go-fqdn v1.0.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.4 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
+	github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e // indirect
 	github.com/antchfx/xmlquery v1.5.1 // indirect
 	github.com/antchfx/xpath v1.3.6 // indirect
 	github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58 // indirect
@@ -141,7 +144,9 @@ require (
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
+	github.com/go-ldap/ldap/v3 v3.4.13 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/cmd/sacloud-otel-collector/go.sum
+++ b/cmd/sacloud-otel-collector/go.sum
@@ -28,6 +28,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
@@ -57,6 +59,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
+github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
+github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/antchfx/xmlquery v1.5.1 h1:T9I4Ns1EXiWHy0IqKupGhnfTQtJwlGrpXtauYOoNv78=
 github.com/antchfx/xmlquery v1.5.1/go.mod h1:bVqnl7TaDXSReKINrhZz+2E/PbCu2tUahb+wZ7WZNT8=
 github.com/antchfx/xpath v1.3.6 h1:s0y+ElRRtTQdfHP609qFu0+c6bglDv20pqOViQjjdPI=
@@ -229,10 +233,14 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 h1:BP4M0CvQ4S3TGls2FvczZtj5Re/2ZzkV9VwqPHH/3Bo=
+github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-ldap/ldap/v3 v3.4.13 h1:+x1nG9h+MZN7h/lUi5Q3UZ0fJ1GyDQYbPvbuH38baDQ=
+github.com/go-ldap/ldap/v3 v3.4.13/go.mod h1:LxsGZV6vbaK0sIvYfsv47rfh4ca0JXokCoKjZxsszv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
@@ -707,6 +715,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.154.0/go.mod h1:kwd68f6YI93OwvqooHZ+wtsflIYiWHKZXSpUKGE07uQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0 h1:MUzX4ChtJ/+p8+2JVCWyPDoxkpHelDSBQeq50wdooGc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.154.0/go.mod h1:osfZC5MYNJ5ZBVAr0BSkKgq6/LjbrN1RqNlxU1h0szs=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0 h1:mbftfQe/15SU1Cfr6hmTHfXOs1+t8VVL4FryGVg/FRY=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.154.0/go.mod h1:u3Bla9+s9aGGxaxkQjqg5oXDpy5lS5IMPEUDbsvbrvU=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -25,22 +25,10 @@ import (
 )
 
 func TestFilelogToSakumock(t *testing.T) {
-	collector, err := filepath.Abs(filepath.Join("..", collectorBinName()))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(collector); err != nil {
-		t.Skipf("%s not found (build it with `make`); skipping e2e", collector)
-	}
-	sakumock, err := exec.LookPath("sakumock-monitoringsuite")
-	if err != nil {
-		t.Skip("sakumock-monitoringsuite not found in PATH; skipping e2e")
-	}
+	collector, sakumock := findBinaries(t)
 
-	// Both servers are external processes, so their ports must be picked
-	// before they start; freeLoopbackAddr is racy but good enough here.
-	dataPlaneAddr := freeLoopbackAddr(t)   // sakumock data plane (collector exports here)
-	healthCheckAddr := freeLoopbackAddr(t) // collector health_check (readiness probe)
+	dataPlaneAddr := freeLoopbackAddr(t)
+	healthCheckAddr := freeLoopbackAddr(t)
 
 	dumpDir := t.TempDir()
 	startProcess(t, "sakumock", sakumock,
@@ -78,10 +66,7 @@ service:
       receivers: [filelog]
       exporters: [sacloud]
 `, filepath.ToSlash(logFile), dataPlaneAddr, healthCheckAddr)
-	cfgFile := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(cfgFile, []byte(cfg), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	cfgFile := writeConfigFile(t, cfg)
 
 	collectorLog := startProcess(t, "collector", collector, "--config", cfgFile)
 	waitListen(t, healthCheckAddr, 60*time.Second)
@@ -93,6 +78,31 @@ service:
 		t.Errorf("no otlp-logs-* dump containing %q in %s; collector log:\n%s",
 			marker, dumpDir, readFile(collectorLog))
 	}
+}
+
+func findBinaries(t *testing.T) (collector, sakumock string) {
+	t.Helper()
+	collector, err := filepath.Abs(filepath.Join("..", collectorBinName()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(collector); err != nil {
+		t.Skipf("%s not found (build it with `make`); skipping e2e", collector)
+	}
+	sakumock, err = exec.LookPath("sakumock-monitoringsuite")
+	if err != nil {
+		t.Skip("sakumock-monitoringsuite not found in PATH; skipping e2e")
+	}
+	return collector, sakumock
+}
+
+func writeConfigFile(t *testing.T, cfg string) string {
+	t.Helper()
+	cfgFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgFile, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cfgFile
 }
 
 func collectorBinName() string {

--- a/e2e/e2e_windows_test.go
+++ b/e2e/e2e_windows_test.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package e2e_test
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestWindowsEventLogToSakumock(t *testing.T) {
+	collector, sakumock := findBinaries(t)
+
+	dataPlaneAddr := freeLoopbackAddr(t)
+	healthCheckAddr := freeLoopbackAddr(t)
+
+	dumpDir := t.TempDir()
+	startProcess(t, "sakumock", sakumock,
+		"--enable-data-plane",
+		"--data-plane-addr", dataPlaneAddr,
+		"--data-plane-dump-dir", dumpDir,
+	)
+	waitListen(t, dataPlaneAddr, 30*time.Second)
+
+	const eventSource = "SacloudOtelE2E"
+	createEventSource(t, eventSource)
+
+	cfg := fmt.Sprintf(`
+receivers:
+  windowseventlog:
+    channel: Application
+    start_at: end
+exporters:
+  sacloud:
+    logs:
+      endpoint: http://%s
+      token: log-dummy
+extensions:
+  health_check:
+    endpoint: %s
+service:
+  telemetry:
+    metrics:
+      level: none
+  extensions: [health_check]
+  pipelines:
+    logs:
+      receivers: [windowseventlog]
+      exporters: [sacloud]
+`, dataPlaneAddr, healthCheckAddr)
+	cfgFile := writeConfigFile(t, cfg)
+
+	collectorLog := startProcess(t, "collector", collector, "--config", cfgFile)
+	waitListen(t, healthCheckAddr, 60*time.Second)
+
+	marker := "sacloud-otel-collector e2e windowseventlog " + randomHex(t)
+	writeEventLog(t, eventSource, marker)
+
+	if !waitForDumpContaining(dumpDir, "otlp-logs-", marker, 60*time.Second) {
+		t.Errorf("no otlp-logs-* dump containing %q in %s; collector log:\n%s",
+			marker, dumpDir, readFile(collectorLog))
+	}
+}
+
+func createEventSource(t *testing.T, source string) {
+	t.Helper()
+	// New-EventLog fails if the source already exists; ignore errors.
+	_ = exec.Command("powershell", "-Command",
+		fmt.Sprintf(`New-EventLog -LogName Application -Source %q -ErrorAction SilentlyContinue`, source),
+	).Run()
+}
+
+func writeEventLog(t *testing.T, source, message string) {
+	t.Helper()
+	cmd := exec.Command("powershell", "-Command",
+		fmt.Sprintf(`Write-EventLog -LogName Application -Source %q -EventId 1000 -EntryType Information -Message %q`,
+			source, message),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Write-EventLog failed: %v\n%s", err, out)
+	}
+}

--- a/e2e/e2e_windows_test.go
+++ b/e2e/e2e_windows_test.go
@@ -65,10 +65,14 @@ service:
 
 func createEventSource(t *testing.T, source string) {
 	t.Helper()
-	// New-EventLog fails if the source already exists; ignore errors.
-	_ = exec.Command("powershell", "-Command",
-		fmt.Sprintf(`New-EventLog -LogName Application -Source %q -ErrorAction SilentlyContinue`, source),
-	).Run()
+	cmd := exec.Command("powershell", "-Command",
+		fmt.Sprintf(`if (-not [System.Diagnostics.EventLog]::SourceExists(%q)) { New-EventLog -LogName Application -Source %q }`,
+			source, source),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("createEventSource failed: %v\n%s", err, out)
+	}
 }
 
 func writeEventLog(t *testing.T, source, message string) {


### PR DESCRIPTION
## Summary

- Add `windowseventlogreceiver` component for collecting Windows Event Logs
  - Compiles on all platforms via build tags; returns a clear error on non-Windows
- Add Windows build job to the PR test workflow (`test.yml`)
- Add e2e test for the receiver on Windows (`e2e_windows_test.go`)
  - Writes to Windows Event Log via PowerShell, verifies the collector forwards it to sakumock

🤖 Generated with [Claude Code](https://claude.com/claude-code)