### PR TITLE
Install sakumock release binary in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,9 +31,25 @@ jobs:
 
       - name: Install sakumock
         shell: bash
-        run: go install "github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@${SAKUMOCK_VERSION}"
+        run: |
+          case "$RUNNER_OS" in
+            Linux) os=linux; ext=tar.gz ;;
+            macOS) os=darwin; ext=tar.gz ;;
+            Windows) os=windows; ext=zip ;;
+          esac
+          case "$RUNNER_ARCH" in
+            X64) arch=amd64 ;;
+            ARM64) arch=arm64 ;;
+          esac
+          asset="sakumock_${SAKUMOCK_VERSION#v}_${os}_${arch}.${ext}"
+          gh release download "$SAKUMOCK_VERSION" -R sacloud/sakumock -p "$asset" -O "$RUNNER_TEMP/$asset"
+          mkdir -p "$RUNNER_TEMP/sakumock-bin"
+          # bsdtar on the Windows runner extracts zip archives as well
+          tar xf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP/sakumock-bin"
+          echo "$RUNNER_TEMP/sakumock-bin" >> "$GITHUB_PATH"
         env:
-          SAKUMOCK_VERSION: v0.6.0
+          SAKUMOCK_VERSION: v0.7.1
+          GH_TOKEN: ${{ github.token }}
 
       - name: Run e2e test
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,10 +42,17 @@ jobs:
             ARM64) arch=arm64 ;;
           esac
           asset="sakumock_${SAKUMOCK_VERSION#v}_${os}_${arch}.${ext}"
-          gh release download "$SAKUMOCK_VERSION" -R sacloud/sakumock -p "$asset" -O "$RUNNER_TEMP/$asset"
-          mkdir -p "$RUNNER_TEMP/sakumock-bin"
-          # bsdtar on the Windows runner extracts zip archives as well
-          tar xf "$RUNNER_TEMP/$asset" -C "$RUNNER_TEMP/sakumock-bin"
+          # Work with paths relative to RUNNER_TEMP: git-bash GNU tar
+          # misparses drive letters (D:\...) as remote host names
+          cd "$RUNNER_TEMP"
+          gh release download "$SAKUMOCK_VERSION" -R sacloud/sakumock -p "$asset" -O "$asset" --clobber
+          mkdir -p sakumock-bin
+          if [ "$ext" = zip ]; then
+            # git-bash GNU tar cannot extract zip; 7z is preinstalled on the Windows runner
+            7z x -y "$asset" -osakumock-bin >/dev/null
+          else
+            tar xf "$asset" -C sakumock-bin
+          fi
           echo "$RUNNER_TEMP/sakumock-bin" >> "$GITHUB_PATH"
         env:
           SAKUMOCK_VERSION: v0.7.1

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,9 +5,9 @@
 // contains what was written.
 //
 // It skips unless ../sacloud-otel-collector (built by `make`) exists and
-// sakumock-monitoringsuite is on PATH:
-//
-//	go install github.com/sacloud/sakumock/monitoringsuite/cmd/sakumock-monitoringsuite@latest
+// sakumock is on PATH (CI downloads the release binary; locally either grab
+// one from https://github.com/sacloud/sakumock/releases or run
+// `go install github.com/sacloud/sakumock/cmd/sakumock@latest`).
 package e2e_test
 
 import (
@@ -31,7 +31,7 @@ func TestFilelogToSakumock(t *testing.T) {
 	healthCheckAddr := freeLoopbackAddr(t)
 
 	dumpDir := t.TempDir()
-	startProcess(t, "sakumock", sakumock,
+	startProcess(t, "sakumock", sakumock, "monitoringsuite",
 		"--enable-data-plane",
 		"--data-plane-addr", dataPlaneAddr,
 		"--data-plane-dump-dir", dumpDir,
@@ -89,9 +89,9 @@ func findBinaries(t *testing.T) (collector, sakumock string) {
 	if _, err := os.Stat(collector); err != nil {
 		t.Skipf("%s not found (build it with `make`); skipping e2e", collector)
 	}
-	sakumock, err = exec.LookPath("sakumock-monitoringsuite")
+	sakumock, err = exec.LookPath("sakumock")
 	if err != nil {
-		t.Skip("sakumock-monitoringsuite not found in PATH; skipping e2e")
+		t.Skip("sakumock not found in PATH; skipping e2e")
 	}
 	return collector, sakumock
 }

--- a/e2e/e2e_windows_test.go
+++ b/e2e/e2e_windows_test.go
@@ -16,7 +16,7 @@ func TestWindowsEventLogToSakumock(t *testing.T) {
 	healthCheckAddr := freeLoopbackAddr(t)
 
 	dumpDir := t.TempDir()
-	startProcess(t, "sakumock", sakumock,
+	startProcess(t, "sakumock", sakumock, "monitoringsuite",
 		"--enable-data-plane",
 		"--data-plane-addr", dataPlaneAddr,
 		"--data-plane-dump-dir", dumpDir,


### PR DESCRIPTION
## What
- Download the prebuilt sakumock release binary in the e2e workflow instead of building `sakumock-monitoringsuite` from source with `go install`
- Update sakumock from v0.6.0 to v0.7.1 (latest)
- Run the umbrella `sakumock` binary with the `monitoringsuite` subcommand in the e2e tests (same flags as the standalone binary)

## Why
Downloading the release binary is faster than compiling sakumock from source on every CI run.

The install step maps `RUNNER_OS` / `RUNNER_ARCH` to the release asset name, downloads it with `gh release download`, and adds the extracted directory to `GITHUB_PATH`. Extraction works relative to `RUNNER_TEMP` because git-bash GNU tar misparses drive-letter paths (`D:\...`) as remote host names, and uses 7z for the Windows zip asset since GNU tar cannot extract zip archives.

The e2e workflow only triggers on push to main, so it was verified on this branch via workflow_dispatch: all three OS jobs pass ([run](https://github.com/sacloud/sacloud-otel-collector/actions/runs/29805430099)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)