### PR TITLE
Enable Go build cache in test and release workflows

### DIFF
--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
+          cache-dependency-path: "**/go.sum"
         id: go
         if: ${{ steps.tagpr.outputs.tag != '' || inputs.tag != '' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "**/go.sum"
         id: go
 
       - name: build and test
@@ -50,6 +51,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
+          cache-dependency-path: "**/go.sum"
 
       - name: build
         shell: bash


### PR DESCRIPTION
## What

Add `cache-dependency-path: "**/go.sum"` to the `setup-go` steps in `test.yml` (both jobs) and `tagpr-release.yml`.

## Why

The repository root has no `go.mod`, so setup-go's default cache resolution fails with a warning (`Restore cache failed: Dependencies file is not found`) and is silently skipped. As a result, every PR run (~6.5 min) and every release run (~29 min, dominated by GoReleaser building 6 targets) compiles the full dependency tree from scratch.

Pointing `cache-dependency-path` at the per-module `go.sum` files (the same approach already used in `e2e.yml`) enables both the module cache and the build cache. The `**/go.sum` glob also covers `exporter/sacloudexporter` and `receiver/selfmetricsreceiver`, so dependency changes in any module invalidate the cache key correctly.

Note: the first run after merge is still cold; speedup applies from the following runs once a main-scoped cache exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)