### PR TITLE
Unify Go cache key across workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
-          cache-dependency-path: cmd/sacloud-otel-collector/go.sum
+          cache-dependency-path: "**/go.sum"
 
       - name: Build collector
         shell: bash


### PR DESCRIPTION
## What

Change `cache-dependency-path` in `e2e.yml` from `cmd/sacloud-otel-collector/go.sum` to `"**/go.sum"`, matching test.yml and tagpr-release.yml (#127).

## Why

setup-go's cache key is derived from OS, Go version, and the hash of the files matched by `cache-dependency-path`, so the previous mismatch prevented cache sharing between workflows. Caches created in PR runs are scoped to that PR, and only main-scoped caches are visible to other runs; since e2e runs on every push to main, aligning its key lets e2e keep main-scoped caches warm for ubuntu/macos/windows, which PR CI and release runs can restore. In particular, the Windows test job previously had no chance of a main-scoped cache and would have stayed cold on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)