### PR TITLE
Use actions/cache with restore-keys for Go caches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,27 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-          cache-dependency-path: "**/go.sum"
+          # setup-go's cache matches keys exactly, and almost every change
+          # in this repo updates go.sum, so it would rarely hit. Use
+          # actions/cache below with restore-keys for prefix fallback.
+          cache: false
+
+      - name: Get Go cache paths
+        id: go-env
+        shell: bash
+        run: |
+          echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.go-env.outputs.gocache }}
+            ${{ steps.go-env.outputs.gomodcache }}
+          key: go-${{ runner.os }}-go1.26-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-go1.26-
 
       - name: Build collector
         shell: bash

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -36,8 +36,23 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-          cache-dependency-path: "**/go.sum"
+          # Disable setup-go's cache: it matches keys exactly and skips
+          # saving on hit, so the small e2e-built cache would occupy the
+          # key and the release's multi-target build cache would never be
+          # saved. Use actions/cache below with restore-keys instead.
+          cache: false
         id: go
+        if: ${{ steps.tagpr.outputs.tag != '' || inputs.tag != '' }}
+
+      - name: Restore Go caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: release-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            release-go-
         if: ${{ steps.tagpr.outputs.tag != '' || inputs.tag != '' }}
 
       - name: go mod download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,28 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/go.sum"
+          # setup-go's cache matches keys exactly, and almost every change
+          # in this repo updates go.sum, so it would rarely hit. Use
+          # actions/cache below with restore-keys for prefix fallback.
+          cache: false
         id: go
+
+      - name: Get Go cache paths
+        id: go-env
+        shell: bash
+        run: |
+          echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.go-env.outputs.gocache }}
+            ${{ steps.go-env.outputs.gomodcache }}
+          key: go-${{ runner.os }}-go${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-go${{ matrix.go-version }}-
 
       - name: build and test
         run: |
@@ -51,7 +71,24 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-          cache-dependency-path: "**/go.sum"
+          cache: false
+
+      - name: Get Go cache paths
+        id: go-env
+        shell: bash
+        run: |
+          echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go caches
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ${{ steps.go-env.outputs.gocache }}
+            ${{ steps.go-env.outputs.gomodcache }}
+          key: go-${{ runner.os }}-go1.26-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-go1.26-
 
       - name: build
         shell: bash


### PR DESCRIPTION
## What

Replace setup-go's built-in cache with explicit `actions/cache` steps in all three workflows:

- `test.yml` / `e2e.yml`: shared key namespace `go-<OS>-go<version>-<hash(**/go.sum)>` with a `restore-keys` prefix fallback. Cache paths are taken from `go env GOCACHE/GOMODCACHE` to handle per-OS path differences.
- `tagpr-release.yml`: separate namespace `release-go-<hash(**/go.sum)>` with prefix fallback.

## Why

The v0.7.4 release run restored a cache but still took ~28 min ([log](https://github.com/sacloud/sacloud-otel-collector/actions/runs/30195605052/job/89776486838)). Two problems with setup-go's cache:

1. **Exact-match only, and no save on hit**: the key unified in #128 was occupied by the small e2e-built cache (1 target, ~967MB), so the release restored an insufficient cache and its own 6-target build cache was never saved — every future release would stay cold.
2. **go.sum changes on almost every PR/release** in this repo (component updates), so exact-match caching rarely hits at all.

`actions/cache` with `restore-keys` solves both: the release gets its own namespace and always saves after go.sum changes, and PR/e2e runs fall back to the most recent cache and rebuild only the delta.

Known limitation: the Go 1.25 test job has no cache producer on main, so it stays cold on the first push of each PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)