### PR TITLE
Update mackerelotlpexporter to v0.15.1

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -14,7 +14,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0
   - gomod: github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter v0.0.0
     path: ./exporter/sacloudexporter
-  - gomod: github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.0
+  - gomod: github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.1
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.154.0

--- a/cmd/sacloud-otel-collector/components.go
+++ b/cmd/sacloud-otel-collector/components.go
@@ -130,7 +130,7 @@ func components() (otelcol.Factories, error) {
 		awss3exporter.NewFactory().Type():                 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.154.0",
 		kafkaexporter.NewFactory().Type():                 "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.154.0",
 		sacloudexporter.NewFactory().Type():               "github.com/sacloud/sacloud-otel-collector/exporter/sacloudexporter v0.0.0",
-		mackerelotlpexporter.NewFactory().Type():          "github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.0",
+		mackerelotlpexporter.NewFactory().Type():          "github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.1",
 	})
 
 	factories.Processors, err = otelcol.MakeFactoryMap[processor.Factory](

--- a/cmd/sacloud-otel-collector/go.mod
+++ b/cmd/sacloud-otel-collector/go.mod
@@ -5,7 +5,7 @@ module go.opentelemetry.io/collector/cmd/builder
 go 1.25.0
 
 require (
-	github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.0
+	github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.154.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.154.0

--- a/cmd/sacloud-otel-collector/go.sum
+++ b/cmd/sacloud-otel-collector/go.sum
@@ -526,8 +526,8 @@ github.com/linode/linodego v1.69.1 h1:f45N2MHR/oece2/ktTTCYmrlfse4//k3NgwcF5zbGZ
 github.com/linode/linodego v1.69.1/go.mod h1:Fha0NYsQSx5VZK1HQNJY/z/dIxxkFp+vb5veawbmAUw=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.0 h1:RmspBhEIZTNL3nZoo55tK0cCldFiSEfSjpbxwDB84xI=
-github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.0/go.mod h1:zjjhjSs2RfeU2Cwvp8jUqs7kUUv2TrA+wie3Vg9wyNQ=
+github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.1 h1:WmLgnr/2OdQgQWeBYfq+XOl2rRkGnVOe28I8xuB+YJY=
+github.com/mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter v0.15.1/go.mod h1:HsDhURKacElFglu7K0Wc08J7wiasHZk7pdYv9/J0J1k=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=


### PR DESCRIPTION
Update mackerelio/opentelemetry-collector-mackerel/exporter/mackerelotlpexporter from v0.15.0 to v0.15.1 to follow the latest upstream release.

Release: https://github.com/mackerelio/opentelemetry-collector-mackerel/releases/tag/exporter%2Fmackerelotlpexporter%2Fv0.15.1

- https://github.com/mackerelio/opentelemetry-collector-mackerel/pull/177
  - https://github.com/mackerelio/opentelemetry-collector-mackerel/pull/174

🤖 Generated with [Claude Code](https://claude.com/claude-code)